### PR TITLE
Remove duplicated hash _key/value_

### DIFF
--- a/lib/green-button-data/enumerations/phase_code.rb
+++ b/lib/green-button-data/enumerations/phase_code.rb
@@ -13,7 +13,6 @@ module GreenButtonData
       66 => :b_c,
       72 => :b_av,
       97 => :b_c_n,  # TODO: Check with GB XML schema maintainers? https://github.com/energyos/OpenESPI-Common-java/blob/master/etc/espiDerived.xsd
-      97 => :a_c_n,
       128 => :a,
       129 => :a_n,
       132 => :a_b,


### PR DESCRIPTION
This removes the warning *duplicated key at line 16 ignored: 97* when starting Rails